### PR TITLE
Switch to specific JDK version 21.0.1

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: '21'
+        java-version: '21.0.1'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven


### PR DESCRIPTION
Check if this JDK difference in the builds is responsible for making the build work:
```
Resolved Java 21.0.1+12 from tool-cache
Setting Java 21.0.1+12 as the default
Creating toolchains.xml for JDK version 21 from temurin
Writing to /home/runner/.m2/toolchains.xml

Java configuration:
  Distribution: temurin
  Version: 21.0.1+12
  Path: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/21.0.1-12/x64
```
Or fail:
```
Resolved Java 21.0.2+13 from tool-cache
Setting Java 21.0.2+13 as the default
Creating toolchains.xml for JDK version 21 from temurin
Writing to /home/runner/.m2/toolchains.xml

Java configuration:
  Distribution: temurin
  Version: 21.0.2+13
  Path: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/21.0.2-13/x64
```

Maven reports:
<details><summary>Maven logs of failure</summary>
<pre><code>[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running net.maisikoleni.javadoc.search.RankedTrieSearchEngineTest
2024-02-04 14:37:00,207 INFO  [net.mai.jav.db.DBManager] (main) Initialize Database
2024-02-04 14:37:00,455 INFO  [one.mic.uti.log.Logging] (main) MicroStream Version 08.01.01-MS-GA
2024-02-04 14:37:00,473 INFO  [one.mic.sto.emb.typ.EmbeddedStorageFoundation$Default] (main) Creating embedded storage manager
2024-02-04 14:37:00,584 INFO  [one.mic.per.typ.PersistenceTypeHandlerManager$Default] (main) Initializing type handler manager
2024-02-04 14:37:00,617 INFO  [one.mic.sto.emb.typ.EmbeddedStorageManager$Default] (main) Starting embedded storage manager
2024-02-04 14:37:00,619 INFO  [one.mic.sto.typ.StorageSystem$Default] (main) Starting storage system
2024-02-04 14:37:00,621 INFO  [one.mic.sto.typ.StorageStructureValidator$Default] (main) Storage structure validated successfully.
2024-02-04 14:37:00,640 INFO  [one.mic.per.typ.PersistenceTypeHandlerManager$Default] (main) Initializing type handler manager
2024-02-04 14:37:00,669 INFO  [one.mic.sto.emb.typ.EmbeddedStorageManager$Default] (main) Embedded storage manager initialized
2024-02-04 14:37:00,670 INFO  [one.mic.per.typ.PersistenceTypeHandlerManager$Default] (main) Initializing type handler manager
2024-02-04 14:37:00,671 INFO  [net.mai.jav.db.DBManager] (main) Database successfully initialized
2024-02-04 14:37:00,672 INFO  [net.mai.jav.ser.JavadocImpl] (main) Fetching JavadocIndex for jdk-latest
2024-02-04 14:37:00,679 WARN  [net.mai.jav.ser.JavadocImpl] (main) Fetching JavadocIndex as resource failed, loading it from the website: net.maisikoleni.javadoc.entities.JavadocIndex$JavadocIndexLoadException: java.lang.NullPointerException: Cannot invoke "java.io.InputStream.readAllBytes()" because "resourceStream" is null
2024-02-04 14:37:04,002 INFO  [net.mai.jav.db.PersistedJavadocIndexes] (main) Storing javadoc index for https://docs.oracle.com/en/java/javase/21/docs/api/
2024-02-04 14:37:04,322 INFO  [net.mai.jav.ser.JavadocImpl] (main) Creating JavadocImpl took 3650 ms.
2024-02-04 14:37:04,322 INFO  [net.mai.jav.ser.JavadocImpl] (main) Fetching JavadocIndex for junit5-latest
2024-02-04 14:37:04,325 WARN  [net.mai.jav.ser.JavadocImpl] (main) Fetching JavadocIndex as resource failed, loading it from the website: net.maisikoleni.javadoc.entities.JavadocIndex$JavadocIndexLoadException: java.lang.NullPointerException: Cannot invoke "java.io.InputStream.readAllBytes()" because "resourceStream" is null
2024-02-04 14:37:04,713 INFO  [net.mai.jav.db.PersistedJavadocIndexes] (main) Storing javadoc index for https://junit.org/junit5/docs/current/api/
2024-02-04 14:37:04,728 INFO  [net.mai.jav.ser.JavadocImpl] (main) Creating JavadocImpl took 406 ms.
2024-02-04 14:37:04,729 INFO  [net.mai.jav.ser.JavadocImpl] (main) Creating JavadocImpl took 1 ms.
2024-02-04 14:37:04,732 DEBUG [net.mai.jav.uti.WeakCommonPool] (main) New WeakCommonPool created.
double free or corruption (out)
Aborted (core dumped)
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:10 min
[INFO] Finished at: 2024-02-04T14:37:34Z
[INFO] ------------------------------------------------------------------------
</code></pre></details>

instead of

<details><summary>Maven logs of success</summary>
<pre><code>[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running net.maisikoleni.javadoc.search.RankedTrieSearchEngineTest
2024-01-29 05:46:36,759 INFO  [net.mai.jav.db.DBManager] (main) Initialize Database
2024-01-29 05:46:37,054 INFO  [one.mic.uti.log.Logging] (main) MicroStream Version 08.01.01-MS-GA
2024-01-29 05:46:37,073 INFO  [one.mic.sto.emb.typ.EmbeddedStorageFoundation$Default] (main) Creating embedded storage manager
2024-01-29 05:46:37,197 INFO  [one.mic.per.typ.PersistenceTypeHandlerManager$Default] (main) Initializing type handler manager
2024-01-29 05:46:37,235 INFO  [one.mic.sto.emb.typ.EmbeddedStorageManager$Default] (main) Starting embedded storage manager
2024-01-29 05:46:37,236 INFO  [one.mic.sto.typ.StorageSystem$Default] (main) Starting storage system
2024-01-29 05:46:37,238 INFO  [one.mic.sto.typ.StorageStructureValidator$Default] (main) Storage structure validated successfully.
2024-01-29 05:46:37,257 INFO  [one.mic.per.typ.PersistenceTypeHandlerManager$Default] (main) Initializing type handler manager
2024-01-29 05:46:37,287 INFO  [one.mic.sto.emb.typ.EmbeddedStorageManager$Default] (main) Embedded storage manager initialized
2024-01-29 05:46:37,287 INFO  [one.mic.per.typ.PersistenceTypeHandlerManager$Default] (main) Initializing type handler manager
2024-01-29 05:46:37,288 INFO  [net.mai.jav.db.DBManager] (main) Database successfully initialized
2024-01-29 05:46:37,290 INFO  [net.mai.jav.ser.JavadocImpl] (main) Fetching JavadocIndex for jdk-latest
2024-01-29 05:46:37,298 WARN  [net.mai.jav.ser.JavadocImpl] (main) Fetching JavadocIndex as resource failed, loading it from the website: net.maisikoleni.javadoc.entities.JavadocIndex$JavadocIndexLoadException: java.lang.NullPointerException: Cannot invoke "java.io.InputStream.readAllBytes()" because "resourceStream" is null
2024-01-29 05:46:40,191 INFO  [net.mai.jav.db.PersistedJavadocIndexes] (main) Storing javadoc index for https://docs.oracle.com/en/java/javase/21/docs/api/
2024-01-29 05:46:40,468 INFO  [net.mai.jav.ser.JavadocImpl] (main) Creating JavadocImpl took 3179 ms.
2024-01-29 05:46:40,468 INFO  [net.mai.jav.ser.JavadocImpl] (main) Fetching JavadocIndex for junit5-latest
2024-01-29 05:46:40,470 WARN  [net.mai.jav.ser.JavadocImpl] (main) Fetching JavadocIndex as resource failed, loading it from the website: net.maisikoleni.javadoc.entities.JavadocIndex$JavadocIndexLoadException: java.lang.NullPointerException: Cannot invoke "java.io.InputStream.readAllBytes()" because "resourceStream" is null
2024-01-29 05:46:40,833 INFO  [net.mai.jav.db.PersistedJavadocIndexes] (main) Storing javadoc index for https://junit.org/junit5/docs/current/api/
2024-01-29 05:46:40,892 INFO  [net.mai.jav.ser.JavadocImpl] (main) Creating JavadocImpl took 424 ms.
2024-01-29 05:46:40,893 INFO  [net.mai.jav.ser.JavadocImpl] (main) Creating JavadocImpl took 0 ms.
2024-01-29 05:46:40,897 DEBUG [net.mai.jav.uti.WeakCommonPool] (main) New WeakCommonPool created.
2024-01-29 05:46:43,354 INFO  [net.mai.jav.sea.TrieGenerator] (ForkJoinPool-2-worker-1) Constructing trie took 2333 ms (trie: RankedConcurrentTrie, parallel: true)
...
</code></pre></details>
The logs don't show any significant difference up to the point the JVM crashed.

The timing might be interesting here:
```
2024-02-04T14:37:04.8002780Z 2024-02-04 14:37:04,732 DEBUG [net.mai.jav.uti.WeakCommonPool] (main) New WeakCommonPool created.
2024-02-04T14:37:05.3426445Z double free or corruption (out)
2024-02-04T14:37:34.8898881Z Aborted (core dumped)
``` 
compared to
```
2024-01-29T05:46:40.9058250Z 2024-01-29 05:46:40,897 DEBUG [net.mai.jav.uti.WeakCommonPool] (main) New WeakCommonPool created.
2024-01-29T05:46:43.4208098Z 2024-01-29 05:46:43,354 INFO  [net.mai.jav.sea.TrieGenerator] (ForkJoinPool-2-worker-1) Constructing trie took 2333 ms (trie: RankedConcurrentTrie, parallel: true)
```



This will require further investigation. (Could be related to low-level code)